### PR TITLE
Update to 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.3-SNAPSHOT'
+    id 'fabric-loom' version '1.5-SNAPSHOT'
 }
 
 sourceCompatibility = targetCompatibility = JavaVersion.VERSION_17
@@ -23,7 +23,7 @@ dependencies {
 
     // Meteor
     modImplementation "meteordevelopment:meteor-client:${project.meteor_version}-SNAPSHOT"
-	modImplementation "baritone:fabric:${project.minecraft_version}-SNAPSHOT"
+    modImplementation "baritone:fabric:${project.baritone_version}-SNAPSHOT"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,14 @@
 # Fabric (https://fabricmc.net/versions.html)
 org.gradle.jvmargs=-Xmx4G
 
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.1
-loader_version=0.14.21
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.7
 
 # Mod Properties
 mod_version=1.0
 maven_group=com.kkllffaa
 archives_base_name=meteor-utils
 
-meteor_version=0.5.4
+meteor_version=0.5.6
+baritone_version=1.20.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/kkllffaa/meteorutils/commands/Disconnect.java
+++ b/src/main/java/com/kkllffaa/meteorutils/commands/Disconnect.java
@@ -3,7 +3,7 @@ package com.kkllffaa.meteorutils.commands;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
 import net.minecraft.command.CommandSource;
-import net.minecraft.network.packet.s2c.play.DisconnectS2CPacket;
+import net.minecraft.network.packet.s2c.common.DisconnectS2CPacket;
 import net.minecraft.text.Text;
 
 import static com.mojang.brigadier.Command.SINGLE_SUCCESS;

--- a/src/main/java/com/kkllffaa/meteorutils/mixins/EchestMemoryMixin.java
+++ b/src/main/java/com/kkllffaa/meteorutils/mixins/EchestMemoryMixin.java
@@ -64,7 +64,7 @@ public abstract class EchestMemoryMixin {
 			getSaveFile().getParentFile().mkdir();
 			getSaveFile().createNewFile();
 			
-			NbtIo.write(tag, getSaveFile());
+			NbtIo.write(tag, getSaveFile().toPath());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
@@ -77,7 +77,7 @@ public abstract class EchestMemoryMixin {
 		
 		NbtCompound tag = null;
 		try {
-			tag = NbtIo.read(getSaveFile());
+			tag = NbtIo.read(getSaveFile().toPath());
 		} catch (IOException e) {
 			if (!(e instanceof FileNotFoundException)) e.printStackTrace();
 		}

--- a/src/main/java/com/kkllffaa/meteorutils/mixins/StashFinderMixin.java
+++ b/src/main/java/com/kkllffaa/meteorutils/mixins/StashFinderMixin.java
@@ -67,16 +67,16 @@ public abstract class StashFinderMixin extends Module {
 	private void debil(ChunkDataEvent event, CallbackInfo ci) {
 		
 		for (StashFinder.Chunk chunk : chunks) {
-			if (noMessageWhenEquals.get() && chunk.chunkPos.equals(event.chunk.getPos())) cancelMessage = true;
+			if (noMessageWhenEquals.get() && chunk.chunkPos.equals(event.chunk().getPos())) cancelMessage = true;
 			
-			if (chunk.chunkPos.getChebyshevDistance(event.chunk.getPos()) < ignoreNeighbourDistance.get()) {
+			if (chunk.chunkPos.getChebyshevDistance(event.chunk().getPos()) < ignoreNeighbourDistance.get()) {
 				ci.cancel();
 				return;
 			}
 		}
 		
 		for (Waypoint waypoint : Waypoints.get()) {
-			if (waypoint.dimension.get() == Dimension.Overworld && new Vec3i(waypoint.pos.get().getX(), waypoint.pos.get().getY(), 0).isWithinDistance(event.chunk.getPos().getCenterAtY(0), ignoreWaypointDistance.get())) {
+			if (waypoint.dimension.get() == Dimension.Overworld && new Vec3i(waypoint.pos.get().getX(), waypoint.pos.get().getY(), 0).isWithinDistance(event.chunk().getPos().getCenterAtY(0), ignoreWaypointDistance.get())) {
 				ci.cancel();
 				return;
 			}

--- a/src/main/java/com/kkllffaa/meteorutils/modules/ShulkerDupe.java
+++ b/src/main/java/com/kkllffaa/meteorutils/modules/ShulkerDupe.java
@@ -31,11 +31,11 @@ public class ShulkerDupe extends Module {
 		if (mc.player != null && event.packet instanceof PlayerActionC2SPacket actionC2SPacket) {
 			if (actionC2SPacket.getAction() == PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK) {
 				if (shoulddupe == ShouldDupe.ONE) {
-					InvUtils.quickMove().slotId(0);
+					InvUtils.shiftClick().slotId(0);
 					shoulddupe = ShouldDupe.NO;
 				} else if (shoulddupe == ShouldDupe.ALL) {
 					for (int i = 0; i < 27; i++) {
-						InvUtils.quickMove().slotId(i);
+						InvUtils.shiftClick().slotId(i);
 					}
 					shoulddupe = ShouldDupe.NO;
 				}

--- a/src/main/java/com/kkllffaa/meteorutils/tabs/WaypointsTab.java
+++ b/src/main/java/com/kkllffaa/meteorutils/tabs/WaypointsTab.java
@@ -110,13 +110,13 @@ public class WaypointsTab extends Tab {
 		public WaypointsListScreen(GuiTheme theme, File file, Runnable action) throws IOException {
 			super(theme, file.getName());
 			this.action = action;
-			this.waypoints = new Waypoints().fromTag(NbtIo.read(file));
+			this.waypoints = new Waypoints().fromTag(NbtIo.read(file.toPath()));
 			
 			
 			WHorizontalList horizontalList = add(theme.horizontalList()).expandX().widget();
 			horizontalList.add(theme.button("save")).expandX().widget().action = () -> {
 				try {
-					NbtIo.write(waypoints.toTag(), file);
+					NbtIo.write(waypoints.toTag(), file.toPath());
 				} catch (IOException e) {
 					e.printStackTrace();
 					close();

--- a/src/main/java/com/kkllffaa/meteorutils/utils/MyInvUtils.java
+++ b/src/main/java/com/kkllffaa/meteorutils/utils/MyInvUtils.java
@@ -20,7 +20,7 @@ public class MyInvUtils {
 			}else {
 				FindItemResult empty = InvUtils.findEmpty();
 				if (empty.found() && empty.isHotbar()) {
-					if (quickmove && !(mc.currentScreen instanceof GenericContainerScreen)) InvUtils.quickMove().from(item.slot()).toHotbar(empty.slot());
+					if (quickmove && !(mc.currentScreen instanceof GenericContainerScreen)) InvUtils.shiftClick().from(item.slot()).toHotbar(empty.slot());
 					else InvUtils.move().from(item.slot()).toHotbar(empty.slot());
 					InvUtils.swap(empty.slot(), false);
 					return true;


### PR DESCRIPTION
Some notable changes:

## Gradle

I basically just copied your commit in the [meteor-litematica-printer](https://github.com/kkllffaa/meteor-litematica-printer) repo.

## Minecraft

- Class `DisconnectS2CPacket` was moved to `net.minecraft.network.packet.s2c.common`.
- `Nbtio.read` and `Nbtio.write` no longer accepts `File` - you have to pass a `Path` object to it. `write` still supports `DataOutput` as input parameter but somehow `read` doesn't, so I just went the lazy route and used `File.toPath`.

## Meteor

- `InvUtils.quickMove` was renamed as `InvUtils.shiftClick`. There's also a `quickSwap` method but I don't really know if this can be used for the intended results.
- `ChunkDataEvent.chunk` is now an accessor method, not a data member.
